### PR TITLE
enable deprecation warnings for running tests (#8)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Run Tests
         run: |
           python -m compileall ${APP_NAME}/
-          coverage run ${APP_NAME}/test.py -v
+          python -Wd -m coverage run ${APP_NAME}/test.py -v
 
       - name: Report Test Coverage
         env:

--- a/uw_coda/tests/test_endpoints.py
+++ b/uw_coda/tests/test_endpoints.py
@@ -25,6 +25,5 @@ class TestEndpoints(TestCase):
         self.assertEqual(fail_rate['current_median'], 3.4)
 
     def test_secondary(self):
-
         fail_rate = uw_coda.get_course_cgpa(POL_S_AA_LABEL)
-        self.assertEquals(fail_rate, {})
+        self.assertEqual(fail_rate, {})


### PR DESCRIPTION
enable deprecation warnings for running tests, fix deprecated method name